### PR TITLE
Fix optional raven dependency not being optional [1.0.1]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ celerybeat-schedule
 
 # dotenv
 .env
+.envrc
 
 # virtualenv
 .venv

--- a/.pylintrc
+++ b/.pylintrc
@@ -50,7 +50,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=no-self-use,ungrouped-imports,import-error
+disable=no-self-use,ungrouped-imports,import-error,duplicate-code
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/Pipfile
+++ b/Pipfile
@@ -8,8 +8,7 @@ name = "pypi"
 [packages]
 
 Flask = "*"
-raven = "*"
-"raven[flask]" = "*"
+raven = {version = "*", extras = ["flask"]}
 
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,18 +1,18 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "52748d3c77a19df4fc99f94293f7997029789e8b1256518d5fc08855597f4b5e"
+            "sha256": "a2b78fafd059b562189d2b49baa429548614fd14cd5e923d29463932e2e74f00"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
-            "implementation_version": "3.6.3",
+            "implementation_version": "3.6.4",
             "os_name": "posix",
             "platform_machine": "x86_64",
             "platform_python_implementation": "CPython",
             "platform_release": "17.4.0",
             "platform_system": "Darwin",
             "platform_version": "Darwin Kernel Version 17.4.0: Sun Dec 17 09:19:54 PST 2017; root:xnu-4570.41.2~1/RELEASE_X86_64",
-            "python_full_version": "3.6.3",
+            "python_full_version": "3.6.4",
             "python_version": "3.6",
             "sys_platform": "darwin"
         },
@@ -39,14 +39,6 @@
                 "sha256:f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b"
             ],
             "version": "==6.7"
-        },
-        "contextlib2": {
-            "hashes": [
-                "sha256:f5260a6e679d2ff42ec91ec5252f4eeffdcf21053db9113bd0a8e4d953769c00",
-                "sha256:509f9419ee91cdd00ba34443217d5ca51f5a364a404e1dce9e8979cea969ca48"
-            ],
-            "markers": "python_version < '3.2'",
-            "version": "==0.5.5"
         },
         "flask": {
             "hashes": [
@@ -76,10 +68,10 @@
         },
         "raven": {
             "hashes": [
-                "sha256:0adae40e004dfe2181d1f2883aa3d4ca1cf16dbe449ae4b445b011c6eb220a90",
-                "sha256:84da75114739191bdf2388f296ffd6177e83567a7fbaf2701e034ad6026e4f3b"
+                "sha256:738a52019d01955d5b44b49d67c9f2f4cedb1b4f70d4fb0b493931174d00e044",
+                "sha256:92bf4c4819472ed20f1b9905eeeafe1bc6fe5f273d7c14506fdb8fb3a6ab2074"
             ],
-            "version": "==6.5.0"
+            "version": "==6.6.0"
         },
         "werkzeug": {
             "hashes": [
@@ -97,14 +89,6 @@
             ],
             "version": "==1.6.1"
         },
-        "backports.functools-lru-cache": {
-            "hashes": [
-                "sha256:f0b0e4eba956de51238e17573b7087e852dfe9854afd2e9c873f73fc0ca0a6dd",
-                "sha256:9d98697f088eb1b0fa451391f91afb5e3ebde16bbdb272819fd091151fda4f1a"
-            ],
-            "markers": "python_version < '3.4'",
-            "version": "==1.5"
-        },
         "certifi": {
             "hashes": [
                 "sha256:14131608ad2fd56836d33a71ee60fa1c82bc9d2c8d98b7bdbc631fe1b3cd1296",
@@ -118,13 +102,6 @@
                 "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
             ],
             "version": "==3.0.4"
-        },
-        "configparser": {
-            "hashes": [
-                "sha256:5308b47021bc2340965c371f0f058cc6971a04502638d4244225c49d80db273a"
-            ],
-            "markers": "python_version < '3.2'",
-            "version": "==3.5.0"
         },
         "coverage": {
             "hashes": [
@@ -158,29 +135,12 @@
             ],
             "version": "==4.0.3"
         },
-        "enum34": {
-            "hashes": [
-                "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
-                "sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a",
-                "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1",
-                "sha256:2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850"
-            ],
-            "markers": "python_version < '3.4'",
-            "version": "==1.1.6"
-        },
         "flake8": {
             "hashes": [
                 "sha256:c7841163e2b576d435799169b78703ad6ac1bbb0f199994fc05f700b2a90ea37",
                 "sha256:7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0"
             ],
             "version": "==3.5.0"
-        },
-        "futures": {
-            "hashes": [
-                "sha256:c4884a65654a7c45435063e14ae85280eb1f111d94e542396717ba9828c4337f",
-                "sha256:51ecb45f0add83c806c68e4b06106f90db260585b25ef2abfcda0bd95c0132fd"
-            ],
-            "version": "==3.1.1"
         },
         "idna": {
             "hashes": [
@@ -191,11 +151,11 @@
         },
         "isort": {
             "hashes": [
-                "sha256:75e94757591197eb0afeb1f3b54f6517c1a26fecaeab2b373885739f63de3e66",
-                "sha256:77502c541ad5c40a158932498bf6177bb663d8a2662b50f02a59b906419ba699",
-                "sha256:34929af733faadf884da29d83e7df1884363b3cc647a48e000b3c5cc13d17549"
+                "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497",
+                "sha256:1153601da39a25b14ddc54955dbbacbb6b2d19135386699e2ad58517953b34af",
+                "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8"
             ],
-            "version": "==4.3.3"
+            "version": "==4.3.4"
         },
         "lazy-object-proxy": {
             "hashes": [
@@ -304,14 +264,6 @@
                 "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
             ],
             "version": "==2.18.4"
-        },
-        "singledispatch": {
-            "hashes": [
-                "sha256:833b46966687b3de7f438c761ac475213e53b306740f1abfaa86e1d1aae56aa8",
-                "sha256:5b06af87df13818d14f08a028e42f566640aef80805c3b50c5056b086e3c2b9c"
-            ],
-            "markers": "python_version < '3.4'",
-            "version": "==3.4.0.3"
         },
         "six": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -9,9 +9,13 @@ This project requires Python 3.6 and Flask 0.12
 
 ## Installation
 
-To install it, simply run
+To install it without Sentry support, simply run
 
     pip install flask-logger
+
+To install it with Sentry support, run
+
+    pip install flask-logger[Sentry]
 
 ## Usage
 

--- a/flask_logger/extension.py
+++ b/flask_logger/extension.py
@@ -2,8 +2,12 @@
 import logging
 import sys
 
-from raven import Client
-from raven.handlers.logging import SentryHandler
+try:
+    from raven import Client
+    from raven.handlers.logging import SentryHandler
+    RAVEN_IMPORTED = True
+except ImportError:
+    RAVEN_IMPORTED = False
 
 LOGGERS = {}
 
@@ -47,6 +51,9 @@ class Logger(object):
         return logger
 
     def _setup_sentry(self, logger, dsn):
+        if not RAVEN_IMPORTED:
+            raise Exception('If specifying SENTRY_DSN, raven must be installed'
+                            ' (pip install flask-logger[Sentry])')
         sentry_client = Client(dsn, auto_log_stacks=True)
         sentry_handler = SentryHandler(sentry_client)
         sentry_handler.setLevel(logging.ERROR)

--- a/flask_logger/tests/test_extension.py
+++ b/flask_logger/tests/test_extension.py
@@ -1,5 +1,6 @@
 """Test the logger extension module."""
-# pylint: disable=protected-access,redefined-outer-name,unused-variable
+
+# pylint: disable=protected-access,redefined-outer-name,unused-variable,invalid-name
 import logging
 import unittest
 from unittest.mock import MagicMock, patch
@@ -7,7 +8,7 @@ from unittest.mock import MagicMock, patch
 from flask import Flask
 
 from flask_logger import Logger  # isort:skip
-from flask_logger.extension import LOGGERS  # isort:skip
+from flask_logger import extension  # isort:skip
 
 TEST_DSN = 'http://foo:bar@sentry.local/1?timeout=1'  # Got this from raven-python repo tests
 
@@ -33,8 +34,7 @@ class TestLogger(unittest.TestCase):
         """Tear down tests."""
         self.ctx.pop()
         # reset any mock loggers at module level
-        # pylint: disable=invalid-name
-        LOGGERS = {}  # noqa
+        extension.LOGGERS = {}  # noqa
 
     def test_default_config(self):
         """Test the default configs."""
@@ -67,7 +67,7 @@ class TestLogger(unittest.TestCase):
     def test_log(self):
         """Test reusing same logger to validate module caching."""
         logger = Logger(self.app)
-        LOGGERS[('test', None)] = MagicMock()
+        extension.LOGGERS[('test', None)] = MagicMock()
         self.assertIsInstance(logger._log('test', None), MagicMock)
 
     def test_log_no_logger(self):
@@ -97,7 +97,7 @@ class TestLogger(unittest.TestCase):
         """Test setup stdout."""
         logger = Logger(self.app)
         mock_logger = MagicMock()
-        LOGGERS[('test', None)] = mock_logger
+        extension.LOGGERS[('test', None)] = mock_logger
 
         mock_handler.return_value = MagicMock()
         mock_formatter.return_value = MagicMock()
@@ -112,7 +112,7 @@ class TestLogger(unittest.TestCase):
         """Test debug level logging."""
         logger = Logger(self.app)  # default level is error
         mock_logger = MagicMock()
-        LOGGERS[('foo', None)] = mock_logger
+        extension.LOGGERS[('foo', None)] = mock_logger
 
         logger.debug('foo', 'bar', extra={'foo': 'bar'})
         mock_logger.assert_not_called()
@@ -122,7 +122,7 @@ class TestLogger(unittest.TestCase):
         }
         logger2 = Logger(self.app, config)
         mock_logger2 = MagicMock()
-        LOGGERS[('foo2', None)] = mock_logger2
+        extension.LOGGERS[('foo2', None)] = mock_logger2
 
         mock_logger2.debug = MagicMock()
         logger2.debug('foo2', 'bar', extra={'foo': 'bar'})
@@ -132,7 +132,7 @@ class TestLogger(unittest.TestCase):
         """Test info level logging."""
         logger = Logger(self.app)  # default level is error
         mock_logger = MagicMock()
-        LOGGERS[('foo', None)] = mock_logger
+        extension.LOGGERS[('foo', None)] = mock_logger
 
         logger.info('foo', 'bar', extra={'foo': 'bar'})
         mock_logger.assert_not_called()
@@ -142,7 +142,7 @@ class TestLogger(unittest.TestCase):
         }
         logger2 = Logger(self.app, config)
         mock_logger2 = MagicMock()
-        LOGGERS[('foo2', None)] = mock_logger2
+        extension.LOGGERS[('foo2', None)] = mock_logger2
         mock_logger2.info = MagicMock()
 
         logger2.info('foo2', 'bar', extra={'foo': 'bar'})
@@ -152,7 +152,7 @@ class TestLogger(unittest.TestCase):
         """Test warning level logging."""
         logger = Logger(self.app)  # default level is error
         mock_logger = MagicMock()
-        LOGGERS[('foo', None)] = mock_logger
+        extension.LOGGERS[('foo', None)] = mock_logger
 
         logger.warning('foo', 'bar', extra={'foo': 'bar'})
         mock_logger.assert_not_called()
@@ -162,7 +162,7 @@ class TestLogger(unittest.TestCase):
         }
         logger2 = Logger(self.app, config)
         mock_logger2 = MagicMock()
-        LOGGERS[('foo2', None)] = mock_logger2
+        extension.LOGGERS[('foo2', None)] = mock_logger2
         mock_logger2.warning = MagicMock()
 
         logger2.warning('foo2', 'bar', extra={'foo': 'bar'})
@@ -172,7 +172,7 @@ class TestLogger(unittest.TestCase):
         """Test error level logging."""
         logger = Logger(self.app)  # default level is error
         mock_logger = MagicMock()
-        LOGGERS[('foo', None)] = mock_logger
+        extension.LOGGERS[('foo', None)] = mock_logger
         mock_logger.error = MagicMock()
 
         logger.error('foo', 'bar', extra={'foo': 'bar'})
@@ -182,7 +182,7 @@ class TestLogger(unittest.TestCase):
         """Test critical level logging."""
         logger = Logger(self.app)  # default level is error
         mock_logger = MagicMock()
-        LOGGERS[('foo', None)] = mock_logger
+        extension.LOGGERS[('foo', None)] = mock_logger
         mock_logger.critical = MagicMock()
 
         logger.critical('foo', 'bar', extra={'foo': 'bar'})
@@ -192,7 +192,7 @@ class TestLogger(unittest.TestCase):
         """Test critical level logging."""
         logger = Logger(self.app)  # default level is error
         mock_logger = MagicMock()
-        LOGGERS[('foo', None)] = mock_logger
+        extension.LOGGERS[('foo', None)] = mock_logger
         mock_logger.exception = MagicMock()
 
         logger.exception('foo', 'bar', extra={'foo': 'bar'})

--- a/flask_logger/tests/test_raven_import.py
+++ b/flask_logger/tests/test_raven_import.py
@@ -1,0 +1,52 @@
+"""Test the logger extension module."""
+# pylint: disable=protected-access,redefined-outer-name,unused-variable,invalid-name
+import importlib
+import sys
+import unittest
+
+import raven
+from flask import Flask
+
+import flask_logger
+
+TEST_DSN = 'http://foo:bar@sentry.local/1?timeout=1'
+
+
+def create_app():
+    """Create a Flask app for context."""
+    app = Flask(__name__)
+    return app
+
+
+class TestRavenImport(unittest.TestCase):
+    """Test logger when raven isn't installed."""
+
+    def setUp(self):
+        """Set up tests."""
+        # Force flask_logger to load without raven in the environment
+        sys.modules['raven'] = None
+        importlib.reload(flask_logger.extension)
+        self.app = create_app()
+        self.ctx = self.app.app_context()
+        self.ctx.push()
+
+    def tearDown(self):
+        """Tear down tests."""
+        self.ctx.pop()
+        # reset any mock loggers at module level
+        # pylint: disable=invalid-name
+        LOGGERS = {}  # noqa
+        sys.modules['raven'] = raven
+        # Reload flask logger to restore sys.modules to correct state
+        importlib.reload(flask_logger.extension)
+
+    def test_log_without_raven(self):
+        """Test establishing logger when raven isn't installed."""
+        logger = flask_logger.Logger()
+        logger.init_app(self.app)
+        with self.assertRaises(Exception) as context:
+            logger.error('no_raven_logger', 'this will raise an exception', dsn=TEST_DSN)
+        self.assertEqual(
+            str(context.exception),
+            'If specifying SENTRY_DSN, raven must be installed (pip install flask-logger[Sentry])'
+        )

--- a/pre-commit
+++ b/pre-commit
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "> let's make sure we're not on master..."
+branch=`git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/\1/'`
+if [ "$branch" == "master" ]
+then
+    echo "Cannot commit to master, please create a dev branch."
+    exit 1
+else
+    echo "$branch ok, continuing..."
+fi
+echo
+
+. ./linters.sh

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@ from setuptools import setup
 
 setup(
     name='Flask-Logger',
-    version='1.0.0',
+    version='1.0.1',
     url='https://github.com/bbelyeu/flask-logger',
-    download_url='https://github.com/bbelyeu/flask-logger/archive/1.0.0.zip',
+    download_url='https://github.com/bbelyeu/flask-logger/archive/1.0.1.zip',
     license='MIT',
     author='Brad Belyeu',
     author_email='bradleylamar@gmail.com',
@@ -18,6 +18,9 @@ setup(
     install_requires=[
         'Flask'
     ],
+    extras_require={
+        'Sentry': ['raven']
+    },
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',


### PR DESCRIPTION
The main aim of this PR is to fix a bug in `extension.py` in which the code would blindly try to import parts of the `raven` package despite it not being a required dependency in the flask-logger PyPI package. The import now gracefully fails and informs the rest of the code execution as to whether or not `raven` was successfully imported. raven is also now listed as an optional dependency that can be automatically installed alongside flask-logger by doing `pip install flask-logger[raven]` or changing `flask-logger = "*"` to `flask-logger = {extras = ["raven"], version = "*"}` in a Pipfile.

Versioned to 1.0.1

Some other small things included in this PR:
- Updated README to reflect optional raven dependency and how to install with/without
- [fixed] pre-commit script was not included in the repo
- Now ignoring both .env and .envrc in .gitignore so users can pick between autoenv and direnv
- Disabled duplicate-code warnings in pylint globally; tried to do it at the file level and it refused to suppress it (research online seemed to suggest there is a pylint bug that other users are suffering from as well)
- Refactored Pipfile to correctly import raven and its optional Flask dependency on the same line (as shown in the lock file, the same packages are installed by either approach)
- Cleaned unneeded packages out of the Pipfile.lock caused by pipenv running in python2 at some point